### PR TITLE
Solutions controller specs

### DIFF
--- a/spec/controllers/solutions_controller_spec.rb
+++ b/spec/controllers/solutions_controller_spec.rb
@@ -70,7 +70,10 @@ describe SolutionsController do
     end
 
     it "assigns the solution to @solution" do
+      task.solutions.should_receive(:find).with('10').and_return(solution)
+
       get :show, :task_id => '42', :id => '10'
+
       assigns(:solution).should == solution
     end
   end


### PR DESCRIPTION
Тук е нужна промяна, която да отрази новия начин за извличане на `@solution` в `SolutionsController` (вж. skanev/evans@8b07582419). Имам няколко въпроса и бележки, обаче:
- Бих искал да обсъдим малко `@task.solituons.find()`, тестваемостта му, дали да стане `Task#find_solution` или не и прочее неща.
- Как да тестваме, че извлеченият `Solution` задължително принадлежи на съответния `Task`?
- Не сме тествали нищо в ситуация с не-логнати потребители в този spec, доколкото виждам. Правим ли това някъде другаде и ако не, смятате ли, че има смисъл да го добавим и как ще изглежда?
