### PR TITLE
Toggle current solution code line numbers

### DIFF
--- a/app/assets/javascripts/tasks.js
+++ b/app/assets/javascripts/tasks.js
@@ -47,4 +47,17 @@ $(function() {
       .click()
       .insertBefore(codeBlock);
   });
+  
+  $('[data-current-solution]').each(function() {
+    var codeBlock       = $(this), 
+        codeLineNumbers = codeBlock.find('td:even');
+
+    $('<a href="#" class="toggle-numbers"></a>')
+      .toggle(
+        function() { $(this).html('Скрий номерата'); codeLineNumbers.show(); },
+        function() { $(this).html('Покажи номерата'); codeLineNumbers.hide(); }
+      )
+      .click()
+      .insertBefore(codeBlock);
+  });
 });

--- a/app/views/solutions/show.html.haml
+++ b/app/views/solutions/show.html.haml
@@ -21,7 +21,7 @@
         %li.failed-tests #{@solution.failed_tests} неуспешни тест(а)
 
   %h2 Код
-  = format_code @solution.code
+  %div(data-current-solution)= format_code @solution.code
 
   - if @solution.log.present?
     %h2 Лог от изпълнението


### PR DESCRIPTION
Понякога искам да избера кода на някое домашно, за да мога да го пусна по-лесно локално. В момента не мога лесно да направя това, без да се налага след това да изтрия номерата на редовете след копирането.

Това добавя малко ликче в стила на `▸ Покажи кода` към последното решение. Не мисля че има смисъл да се добавя към ревизиите, тъй като е по-малко вероятно да искаме да пробваме стар код, а и ще трябва да се мисли още UI, тъй като според мене не изглежда добре до `▸ Покажи кода`.

Някакви други идеи за UI?
