### PR TITLE
Keep registered users Skype accounts safe from internet bots.

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,7 +14,7 @@
       %dt Twitter
       %dd= link_to @user.twitter, "http://twitter.com/#{@user.twitter}"
 
-    - if @user.skype.present?
+    - if logged_in? and @user.skype.present?
       %dt Skype
       %dd= @user.skype
 


### PR DESCRIPTION
Keep Skype accounts safe from internet bots.
This is in response to some Skype spam the other year, caused by
putting my Skype account on my Python course account. This caused
a week full of spam until I removed Skype from my Python course user.
