### PR TITLE
Turbolinks за по-бърз потребителски интерфейс

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'coderay'
 
 gem 'exception_notification'
 gem 'jquery-rails'
+gem 'turbolinks'
+gem 'jquery-turbolinks'
 
 # Sidekiq and its dependencies
 gem 'sidekiq'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -124,6 +124,8 @@ GEM
     jquery-rails (2.0.2)
       railties (>= 3.2.0, < 5.0)
       thor (~> 0.14)
+    jquery-turbolinks (0.2.1)
+      rails (>= 3.1.0)
     json (1.7.7)
     launchy (2.1.0)
       addressable (~> 2.2.6)
@@ -264,6 +266,8 @@ GEM
     turbo-sprockets-rails3 (0.3.6)
       railties (> 3.2.8, < 4.0.0)
       sprockets (>= 2.0.0)
+    turbolinks (1.0.0)
+      coffee-rails
     tzinfo (0.3.35)
     uglifier (1.2.6)
       execjs (>= 0.3.0)
@@ -301,6 +305,7 @@ DEPENDENCIES
   guard-sass
   haml
   jquery-rails
+  jquery-turbolinks
   launchy
   mini_magick
   pg
@@ -322,6 +327,7 @@ DEPENDENCIES
   therubyracer
   timecop
   turbo-sprockets-rails3
+  turbolinks
   uglifier
   webrat
   will_paginate

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -1,5 +1,7 @@
 /*
+ *= require turbolinks
  *= require jquery
+ *= require jquery.turbolinks
  *= require jquery_ujs
  *= require modernizr
  *


### PR DESCRIPTION
[Turbolinks](https://github.com/rails/turbolinks) е клиентска библиотека, която прихваща всички линкове на страницата и се опитва да презареди само тялото и титлата, където това се потдържа. [Turbolinks](https://github.com/rails/turbolinks) ще бъде част от Rails 4 и най-вероятно ще е включена по подразбиране.

Това има предимството или недостатъка, че `JavaScript` и `CSS` сесиите се запазват, т.е. динамичното добавяне на скриптове и стилове може да е проблемно.

При `evans` няма такива гимнастики и мисля, че е добро време за това да се изпробва. При мен нямаше проблеми - POST-овете презареждаха, `JavaScript`/`CSS` сесиите се запазваха и т.н.

Ако виждате някакви такива, споделете.
