### PR TITLE
По-удобни имейли в development чрез letter_opener

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ end
 
 group :development do
   gem 'pry'
+  gem 'letter_opener'
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,6 +135,8 @@ GEM
     json (1.8.0)
     launchy (2.3.0)
       addressable (~> 2.3)
+    letter_opener (1.1.2)
+      launchy (~> 2.2)
     libv8 (3.16.14.3)
     listen (1.3.1)
       rb-fsevent (>= 0.9.3)
@@ -326,6 +328,7 @@ DEPENDENCIES
   haml
   jquery-rails
   launchy
+  letter_opener
   mini_magick
   pg
   protected_attributes

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -15,6 +15,10 @@ Trane::Application.configure do
   # Don't care if the mailer can't send
   config.action_mailer.raise_delivery_errors = false
 
+  # Use https://github.com/ryanb/letter_opener to open
+  # emails locally in the browser instead of sending them
+  config.action_mailer.delivery_method = :letter_opener
+
   # Set a default host that will be used in all mailers
   config.action_mailer.default_url_options = {:host => 'trane.example.org'}
 


### PR DESCRIPTION
Ако не сте чували за [letter_opener](https://github.com/ryanb/letter_opener), това е един малък gem на Ryan Bates, който се слага като delivery method в `development.rb` и вместо да се изпращат писмата по SMTP, се отварят във вашия браузър. Много удобно за разработка.

Изглежда горе-долу така:
![Letter Opener Preview](http://dl.dropbox.com/u/2664150/Screenshots/f77-_6k3nkdu.png)

Писмата се запазват в една папка в tmp/ и се отварят от там с помощта на [launchy](https://github.com/copiousfreetime/launchy). Има само един потенциален недостатък (цитат от readme-то на letter_opener):

> Letter Opener uses Launchy to open sent mail in the browser. This assumes the Ruby process is running on the local development machine. If you are using a separate staging server or VM this will not work. In that case consider using Mailtrap or MailCatcher.

Все пак си мисля, че си заслужава да го ползваме. Хайде някой, който е на Linux distro (@psstoev, @ignisf?), да потвърди, че това работи при него и ако ви кефи, да го merge-ваме.
