### PR TITLE
Задаване на версията на Ruby в Gemfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ gems.tags
 .sass-cache
 .rvmrc
 .rbenv-version
+.ruby-version
 .ruby-gemset
 .powrc
 public/lectures

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'http://rubygems.org'
 
+ruby '2.1.0'
+
 gem 'rails', '~> 4.0.0'
 gem 'pg'
 


### PR DESCRIPTION
С този PR правя две промени:
1. **Добавям `.ruby-version` в `.gitignore`**. С това искам да оставя всеки разработчик да си избира сам какъв Ruby version manager да ползва, както и с какъв Ruby patch level да си движи сайта на локалната машина.
2. **Добавям изискване за версията на Ruby в `Gemfile`-а.** Така major версията на Ruby (2.0.0, 2.1.0 и т.н.) ще се налага от Bundler.

Мотвиация:

В development не е от голямо значение с какъв patch level се изпълнява сайтът на курса, стига major версията на Ruby да е еднаква. Понеже не работим в една фирма/организация и сме всякакви прошльовци, събрани от кол и въже, смятам и че всеки трябва да има свободата да си избира с какъв Ruby version manager иска да си трови живота.

Повод:

Наложи се да мигрирам сайта на курса на Ruby 2.1 и на сървъра, заради `skeptic` – ако някой качи решение с Ruby 2.1 синтаксис, `skeptic` се чупи (очаквано).
