### PR TITLE
Fix results table falling to multiple rows

### DIFF
--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -9,8 +9,8 @@
 table.solutions {
   @include data-table;
 
-  .points { width: 150px; }
-  .results { width: 195px; }
+  .points { width: 150px; white-space: nowrap; }
+  .results { width: 180px; white-space: nowrap; }
 
   .results span { display: inline-block; margin-left: 10px; }
   .results span:first-child { margin-left: 0; }


### PR DESCRIPTION
Когато в таблицата с решенията за дадена задача има повече двуцифрени числа в
колоната "Изпълнение", редът се пренасяше на два.

![evans_solutions_table](https://f.cloud.github.com/assets/2514425/1504554/f3a1f6e0-48bf-11e3-87de-d135cd85977f.png)

_offtopic_
Sorry за спама с pull request-и. Май щеше да е по-добре  двете промени да са в един PR, но това го видях след като бях пуснал първия :)
