### PR TITLE
Autofocus voucher input

### DIFF
--- a/app/views/voucher_claims/new.html.haml
+++ b/app/views/voucher_claims/new.html.haml
@@ -12,6 +12,6 @@
 = form_tag voucher_claims_path, method: :post, class: 'simple_form' do
   %div
     = label_tag :code, 'Код'
-    = text_field_tag :code, '', class: 'string'
+    = text_field_tag :code, '', class: 'string', autofocus: true
   %div
     = submit_tag 'Въведи'


### PR DESCRIPTION
Полето за нов код е фокусирано при зареждане на страницата. Този път с ruby 1.9 синтаксис.
