### PR TITLE
Run `go fix` to check for syntax errors

### DIFF
--- a/lib/language/go.rb
+++ b/lib/language/go.rb
@@ -30,7 +30,7 @@ module Language::Go
       result = nil
 
       FileUtils.cd(dir) do
-        result = system "go build #{code_path} > /dev/null 2>&1"
+        result = system "go fix #{code_path} > /dev/null 2>&1"
       end
 
       result


### PR DESCRIPTION
`go build` гърми, ако студентът не си е написал и `main` функция. Все още не съм сигурен, че това е идеалното решение, тъй като `go fix` не мрънка за `unused import`.

Единственото друго решение, за което се сещам е да проверяваме дали има `main` функция в решението и ако няма да добавяме наша.
