### PR TITLE
Use the markup helper when rendering previews

### DIFF
--- a/app/controllers/previews_controller.rb
+++ b/app/controllers/previews_controller.rb
@@ -1,5 +1,6 @@
 class PreviewsController < ApplicationController
   def create
-    render text: Markup.format(params[:body])
+    @body = params[:body]
+    render layout: false
   end
 end

--- a/app/views/previews/create.html.haml
+++ b/app/views/previews/create.html.haml
@@ -1,0 +1,1 @@
+= markup @body

--- a/spec/controllers/previews_controller_spec.rb
+++ b/spec/controllers/previews_controller_spec.rb
@@ -1,0 +1,13 @@
+require 'spec_helper'
+
+describe PreviewsController do
+  describe "POST create" do
+    it "renders a preview of the markup" do
+      post :create, body: 'some markup'
+
+      assigns(:body).should eq 'some markup'
+      response.should render_template(:create)
+      response.should render_template(layout: false)
+    end
+  end
+end


### PR DESCRIPTION
Прегледа на contribution трябва да изглежда по абсолютно същия начин, по който би изглеждал въпросният текст, след като се съхрани и рендерира. За тази цел е добра идея да ползваме същия `markup` helper.

Подсетих се за това от #114 и #115.
