### PR TITLE
Премахване на escaped HTML

### DIFF
--- a/app/views/profiles/edit.html.haml
+++ b/app/views/profiles/edit.html.haml
@@ -21,7 +21,7 @@
 
   %fieldset
     %legend Малко лична информация за вас
-    = form.input :github
+    = form.input :github, label: t('activerecord.attributes.user.github_html')
     = form.input :twitter
     = form.input :skype
     = form.input :phone

--- a/config/locales/bg.yml
+++ b/config/locales/bg.yml
@@ -72,7 +72,8 @@ bg:
         password_confirmation: Въведете паролата повторно
         remember_me: Запомни ме на този компютър
         photo: Снимка
-        github: 'Потребителско име в <a href="http://github.com/">GitHub</a>'
+        github: Потребителско име в GitHub
+        github_html: 'Потребителско име в <a href="http://github.com/">GitHub</a>'
         phone: Мобилен телефон
         site: Сайт
         about: Разкажете ни за себе си


### PR DESCRIPTION
Label-а на "github" input-а в страницата за редактиране на профила вади escaped HTML. Използването на експлицитен превод избягва този проблем.

Алтернативно, може да се ползва `raw` с ключ `github`, вместо `github_html`, но така ако някой някъде не се сети да го ползва, поне ще се рендерира човешки.
