### PR TITLE
Set python test runner niceness to 10

### DIFF
--- a/lib/language/python/runner.py
+++ b/lib/language/python/runner.py
@@ -123,4 +123,6 @@ def main(test_module):
 
 
 if __name__ == '__main__':
+    initial_niceness = os.nice(0)
+    os.nice(10 - initial_niceness)
     print(json.dumps(main(sys.argv.pop())))


### PR DESCRIPTION
По отпочнатата тема в skanev/evans/pull/160.

На теория винаги трябва да почваме с niceness 0, но да речем, че в случая не боли да сме предпазливи.