### PR TITLE
Fix user about info visibility

### DIFF
--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -26,6 +26,7 @@
       %dt Поща
       %dd= @user.email
 
+    - if logged_in?
       %dt За вас
       %dd= @user.about
 
@@ -63,3 +64,4 @@
           - replies.each do |reply|
             %li
               = link_to reply.body.truncate(77), post_path(reply)
+              

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -64,4 +64,3 @@
           - replies.each do |reply|
             %li
               = link_to reply.body.truncate(77), post_path(reply)
-              

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,6 +20,7 @@ FactoryGirl.define do
     faculty_number
     full_name 'John D. Doe'
     name 'John Doe'
+    about 'zdr'
   end
 
   factory :user_with_photo, parent: :user do

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -20,7 +20,6 @@ FactoryGirl.define do
     faculty_number
     full_name 'John D. Doe'
     name 'John Doe'
-    about 'zdr'
   end
 
   factory :user_with_photo, parent: :user do

--- a/spec/views/users/show.html.haml_spec.rb
+++ b/spec/views/users/show.html.haml_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe "users/show.html.haml" do
-  let(:user) { build_stubbed :user }
+  let(:user) { build_stubbed :user, about: 'I am a platypus.' }
 
   before do
     view.stub admin?: false

--- a/spec/views/users/show.html.haml_spec.rb
+++ b/spec/views/users/show.html.haml_spec.rb
@@ -28,6 +28,11 @@ describe "users/show.html.haml" do
       render
       rendered.should_not have_content user.email
     end
+
+    it "does not show the about info" do
+      render
+      rendered.should_not have_content user.about
+    end
   end
 
   context 'when a user is viewing their own profile' do
@@ -49,6 +54,11 @@ describe "users/show.html.haml" do
     it "does not show the email" do
       render
       rendered.should_not have_content user.email
+    end
+
+    it "shows the about info" do
+      render
+      rendered.should have_content user.about
     end
   end
 
@@ -72,6 +82,11 @@ describe "users/show.html.haml" do
       render
       rendered.should_not have_content user.email
     end
+
+    it "shows the about info" do
+      render
+      rendered.should have_content user.about
+    end
   end
 
   context 'when an admin is viewing a profile' do
@@ -89,6 +104,11 @@ describe "users/show.html.haml" do
     it "shows the email" do
       render
       rendered.should have_content user.email
+    end
+
+    it "shows the about info" do
+      render
+      rendered.should have_content user.about
     end
   end
 end


### PR DESCRIPTION
Аbout информацията не бе видима за логнати потребители. След тази поправка се вижда. Дали от  всички да се вижда или само от регистрирани?