### PR TITLE
Add an option to assign yourself as a reviewer for a solution

### DIFF
--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -11,7 +11,10 @@ table.solutions {
 
   .points { width: 150px; white-space: nowrap; }
   .results { width: 180px; white-space: nowrap; }
+  .reviewer { width: 100px; padding: 0; white-space: nowrap; }
 
+  .reviewer img { display: block; margin: 0 auto; width: 30px; height: 30px; }
+  .reviewer input { margin-left: 31px; }
   .results span { display: inline-block; margin-left: 10px; }
   .results span:first-child { margin-left: 0; }
 

--- a/app/controllers/solutions_controller.rb
+++ b/app/controllers/solutions_controller.rb
@@ -42,4 +42,24 @@ class SolutionsController < ApplicationController
       redirect_to task_solutions_path(params[:task_id])
     end
   end
+
+  def review
+    solution = Solution.find params[:id]
+    if solution.reviewer.nil?
+      solution.update! reviewer: current_user
+      flash[:notice] = 'Ти си проверяващ за тази задача'
+    else
+      flash[:error] = 'Вече има проверяващ за тази задача'
+    end
+    redirect_to solution
+  end
+
+  def abandon
+    solution = Solution.find params[:id]
+    if solution.reviewer == current_user
+      solution.update! reviewer: nil
+      flash[:notice] = 'Вече не проверяваш задачата'
+    end
+    redirect_to solution
+  end
 end

--- a/app/models/solution.rb
+++ b/app/models/solution.rb
@@ -1,6 +1,7 @@
 class Solution < ActiveRecord::Base
   belongs_to :user
   belongs_to :task
+  belongs_to :reviewer, class_name: 'User'
 
   has_many :revisions, -> { order 'revisions.id ASC' }
   has_many :comments, -> { order 'comments.created_at ASC' }, through: :revisions

--- a/app/views/solutions/_abandon.html.haml
+++ b/app/views/solutions/_abandon.html.haml
@@ -1,0 +1,2 @@
+= simple_form_for solution, url: abandon_task_solution_path(solution.task, solution), method: :post do |form|
+  = form.button :submit, 'Върни за друг проверяващ'

--- a/app/views/solutions/_review.html.haml
+++ b/app/views/solutions/_review.html.haml
@@ -1,0 +1,2 @@
+= simple_form_for solution, url: review_task_solution_path(solution.task, solution), method: :post do |form|
+  = form.button :submit, info

--- a/app/views/solutions/index.html.haml
+++ b/app/views/solutions/index.html.haml
@@ -22,12 +22,20 @@
   %thead
     %tr
       %th.name Име
+      - if admin?
+        %th.reviewer Проверяващ
       %th.points Точки
       %th.results Изпълнение
   %tbody
     - @solutions.each do |solution|
       %tr
         %td.name= link_to solution.user_name, [@task, solution]
+        - if admin?
+          %td.reviewer
+            - if solution.reviewer
+              = user_thumbnail solution.reviewer, :size30
+            - else
+              = render 'solutions/review', info: '🔎', solution: solution
         %td.points
           - if show_results? @task
             Точки: <span data-points>#{solution.total_points}</span> (<span data-adjustment>#{solution.adjustment}</span> добавка)

--- a/app/views/solutions/show.html.haml
+++ b/app/views/solutions/show.html.haml
@@ -27,6 +27,16 @@
     %h2 Лог от изпълнението
     %pre.test-log(data-toggleable data-show-text="Покажи лога" data-hide-text="Скрий лога")= @solution.log
 
+  - if admin? and @solution.reviewer
+    %h2 Проверяващ
+    = user_thumbnail @solution.reviewer
+
+    - if current_user == @solution.reviewer
+      = render 'solutions/abandon', solution: @solution
+
+  - elsif admin?
+    = render 'solutions/review', info: 'Стани проверяващ', solution: @solution
+
   - if admin?
     = render 'solutions/scoring', solution: @solution
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,10 @@ Trane::Application.routes.draw do
     get :guide, on: :collection
     resources :solutions, only: %w(index show update) do
       get :unscored, on: :collection
+      member do
+        post :review
+        post :abandon
+      end
     end
     resource :my_solution, only: %w(show update)
     resource :check, controller: :task_checks, only: :create

--- a/db/migrate/20151014025613_add_reviewer_to_solutions.rb
+++ b/db/migrate/20151014025613_add_reviewer_to_solutions.rb
@@ -1,0 +1,8 @@
+class AddReviewerToSolutions < ActiveRecord::Migration
+  include ForeignKeys
+
+  def change
+    add_reference :solutions, :reviewer, references: :users, index: true
+    foreign_key :solutions, :reviewer_id, :users
+  end
+end


### PR DESCRIPTION
Тези дни на няколко пъти хора от екипа се оплакваха, че се засичат в коментари по решенията. Имаше и идея за специален канал в Slack за целта.  Един възможен вариант е предложен тук: всеки админ да може да се assign-ва като проверяващ(reviewer) на дадено решение. 

При тази имплементация не може повече от един админ да бъде "reviewer" на едно решение, като логиката за това е 
- мотивацията за цялата функционалност е "това решение вече наглежда ли се от някой", "lock-нато ли е"
- предполага се, че ако някой е почнал да коментира и отговаря на дадено решение, ще му е по-лесно да продължи до края на срока

Разбира се, наличието на "проверяващ" не влияе на възможността други да оставят коментари. Проверяващият за дадено решение обаче се очаква да има основна роля (може и функционалността за бонус точки да се обвърже само с него)

Друга въпросителна е дали да може админ сам да "осинови" решение от друг. В момента това може да стане само ако предишният се откаже от проверката на задачата, но това може би е твърде ограничаващо.

Показваме само снимка на проверяващ в ui, защото снимките изглеждат по-бързо разпознаваеми и компактни(особено в таблицата) и са подходящи за екипа, който е сравнително малък, и се познава взаимно
(за разлика от студентите, които са много и непознати)
Имплементацията в момента е бърз пример в името на дискусията за такъв feature. Затова интерфейсът/функционалността може би не са оптимални(затова и няма тестове все още)

Мнения?

![penguin](https://cloud.githubusercontent.com/assets/830715/10475911/64d2abd6-7251-11e5-8da4-e6829388dba1.png)

![dog](https://cloud.githubusercontent.com/assets/830715/10475918/7580d994-7251-11e5-90cf-6b507ff0b6e9.png)

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/skanev/evans/166)

<!-- Reviewable:end -->
