### PR TITLE
Parametrize the timeout time for solution examples

### DIFF
--- a/lib/language/ruby/run_with_timeout.rb
+++ b/lib/language/ruby/run_with_timeout.rb
@@ -2,6 +2,8 @@ require 'timeout'
 
 RSpec.configure do |config|
   config.around(:each) do |example|
-    Timeout::timeout(1, TimeoutError) { example.run }
+    timeout = example.metadata[:timeout] || 1
+
+    Timeout::timeout(timeout, TimeoutError) { example.run }
   end
 end

--- a/spec/lib/language/running_ruby_tests_spec.rb
+++ b/spec/lib/language/running_ruby_tests_spec.rb
@@ -61,4 +61,40 @@ END
       @results.log.should include("6 examples, 3 failures")
     end
   end
+
+  describe "timeouts" do
+    let(:solution) do
+      <<-RUBY
+        module Homework
+          def self.answer
+            sleep 1.5
+          end
+        end
+      RUBY
+    end
+
+    it "default to one second per example" do
+      test_case = <<-RUBY
+        describe "Homework" do
+          it("timeouts") { Homework.answer }
+        end
+      RUBY
+
+      results = Language::Ruby.run_tests(test_case, solution)
+      results.failed_count.should eq 1
+      results.passed_count.should eq 0
+    end
+
+    it "can be configured per example" do
+      test_case = <<-RUBY
+        describe "Homework" do
+          it("timeouts", timeout: 2) { Homework.answer }
+        end
+      RUBY
+
+      results = Language::Ruby.run_tests(test_case, solution)
+      results.failed_count.should eq 0
+      results.passed_count.should eq 1
+    end
+  end
 end


### PR DESCRIPTION
Понякога е полезно да се увеличи timeout времето за определени тестове в решенията на задачи.

Един такъв пример е тестът за автоматичната проверка на минималните изисквания за ретроспективната задача, която @mitio написа. Проверката клонира хранилището на студента и пуска тестовете на всички задачи. Очевидно, това не минава за под 1 секунда.

В момента проблемът е решен като е изкарана логиката на теста извън RSpec, така че не е болка за умиране и да не се мърджне този PR, но го правя понеже така или иначе направих промените тук.