### PR TITLE
Synchronize output to log file in Ruby task runner

### DIFF
--- a/lib/language/ruby/runner.rb
+++ b/lib/language/ruby/runner.rb
@@ -24,8 +24,7 @@ Dir.mktmpdir do |dir|
     '--format',  'JsonFormatter',
     '--out',     json_path.to_s,
     '--format',  'progress',
-    :err => log_path.to_s,
-    :out => log_path.to_s
+    [:err, :out] => log_path.to_s
 
   if json_path.exist? and not json_path.read.empty?
     puts json_path.read


### PR DESCRIPTION
Ще оставя commit съобщението да говори само:

Redirecting stdout and stderr separately to a single file results in
unsynchronized writes to the file. Running a command which writes to
stdout and stderr results in the two outputs "merging" mid-line and
sometimes mid-utf sequence.

If one of the outputs is inserted in the middle of a utf character
sequence then we get `ArgumentError: invalid byte sequence` when trying
to split the JSON output from the log at `Language::Ruby#run_tests`.

The problem is caused by `system` opening the same file two times
(one for stdout and one for stderr) and writing to it at the same time.

The fix specifies the file redirection of both streams at the same time
so that the file is open only once.

Проблемът се появи с командата `git fetch origin master && git reset --hard origin/master && git clean -f`. `git fetch origin master` пише на stderr, а `git reset --hard origin/master` - на stdout.