### PR TITLE
Prettier diff blocks and a fix for comment aggregation in some cases

### DIFF
--- a/lib/formatted_code/comment_history.rb
+++ b/lib/formatted_code/comment_history.rb
@@ -24,6 +24,8 @@ module FormattedCode
 
         comments = select_active_comments(diff, comments)
         comments = merge_comment_hashes(comments, version.comments_by_line)
+
+        old_version = version
       end
 
       comments

--- a/lib/formatted_code/comment_history.rb
+++ b/lib/formatted_code/comment_history.rb
@@ -32,7 +32,7 @@ module FormattedCode
     private
 
     def diff_code(old_code, new_code)
-      ::Diff::LCS.sdiff(old_code.lines, new_code.lines)
+      Differ.new(old_code, new_code).changes
     end
 
     def select_active_comments(diff, comments_by_line)

--- a/lib/formatted_code/diff.rb
+++ b/lib/formatted_code/diff.rb
@@ -1,7 +1,7 @@
 module FormattedCode
   class Diff
     def initialize(from, to, language, inline_comments)
-      @diff = ::Diff::LCS.sdiff(from.split("\n"), to.split("\n"))
+      @diff = Differ.new(from, to).changes
       @highlighter = Highlighter.new(to, language)
 
       @inline_comments = inline_comments
@@ -17,11 +17,6 @@ module FormattedCode
           [DiffLine.new('-', change.old_element, nil, [])]
         when '+'
           [DiffLine.new('+', new_highlighted_line, change.new_position, comments_for_line)]
-        when '!'
-          [
-            DiffLine.new('-', change.old_element, nil, []),
-            DiffLine.new('+', new_highlighted_line, change.new_position, comments_for_line)
-          ]
         else
           [DiffLine.new('=', new_highlighted_line, change.new_position, comments_for_line)]
         end

--- a/lib/formatted_code/differ.rb
+++ b/lib/formatted_code/differ.rb
@@ -1,0 +1,18 @@
+module FormattedCode
+  class Differ
+    def initialize(old_code, new_code)
+      @old_lines = old_code.split("\n")
+      @new_lines = new_code.split("\n")
+    end
+
+    def changes
+      enum_for :each_change
+    end
+
+    private
+
+    def each_change(&block)
+      ::Diff::LCS.traverse_sequences(@old_lines, @new_lines, &block)
+    end
+  end
+end

--- a/spec/lib/formatted_code/comment_history_spec.rb
+++ b/spec/lib/formatted_code/comment_history_spec.rb
@@ -97,6 +97,35 @@ describe FormattedCode::CommentHistory do
     expect_comments_to_match version_one, version_two, expected
   end
 
+  it 'correctly matches the lines when there are multiple changed lines in a row' do
+    version_one = <<-END
+      Line one
+      Line two
+      # Comment one
+      Line three
+      # Comment two
+    END
+
+    version_two = <<-END
+      Line one!
+      # Comment one!
+      Line two!
+      Line three
+      # Comment three
+    END
+
+    expected = <<-END
+      Line one!
+      # Comment one!
+      Line two!
+      Line three
+      # Comment two
+      # Comment three
+    END
+
+    expect_comments_to_match version_one, version_two, expected
+  end
+
   def expect_comments_to_match(*versions, expected)
     history = FormattedCode::CommentHistory.new
 

--- a/spec/lib/formatted_code/comment_history_spec.rb
+++ b/spec/lib/formatted_code/comment_history_spec.rb
@@ -126,6 +126,60 @@ describe FormattedCode::CommentHistory do
     expect_comments_to_match version_one, version_two, expected
   end
 
+  it 'works across multiple revisions' do
+    version_one = <<-END
+      Line 1
+      Line 2
+    END
+
+    version_two = <<-END
+      Line 1+
+      # Comment on 1+
+      Line 2
+    END
+
+    version_three = <<-END
+      Line 1+
+      # Second comment on 1+
+      Line 2+
+      # Comment on 2+
+    END
+
+    expected = <<-END
+      Line 1+
+      # Comment on 1+
+      # Second comment on 1+
+      Line 2+
+      # Comment on 2+
+    END
+
+    expect_comments_to_match version_one, version_two, version_three, expected
+  end
+
+  it 'compares version pairs step by step, ignoring old comments' do
+    version_one = <<-END
+      Line one
+      # Comment 1
+    END
+
+    version_two = <<-END
+      Line one!
+      # Comment one
+    END
+
+    version_three = <<-END
+      Line one
+      # Comment one!
+    END
+
+    expected = <<-END
+      Line one
+      # Comment one!
+    END
+
+    expect_comments_to_match version_one, version_two, version_three, expected
+  end
+
   def expect_comments_to_match(*versions, expected)
     history = FormattedCode::CommentHistory.new
 

--- a/spec/lib/formatted_code/diff_spec.rb
+++ b/spec/lib/formatted_code/diff_spec.rb
@@ -9,15 +9,13 @@ describe FormattedCode::Diff do
     end
   end
 
-  it 'highlights the code, diffs it and splits it in lines' do
-    comments = {0 => ['one', 'two'], 1 => ['three']}
-
-    first_version = <<-END
+  it 'highlights the code, diffs it and displays comments' do
+    old_version = <<-END
       Old line
       Code
     END
 
-    second_version = <<-END
+    new_version = <<-END
       New line
       # Comment one
       # Comment two
@@ -25,33 +23,75 @@ describe FormattedCode::Diff do
       # Comment three
     END
 
-    code = FormattedCode::Diff.new(
-      code_from_version(first_version),
-      code_from_version(second_version),
-      'ruby',
-      comments_from_version(second_version)
-    )
-    lines = code.lines
+    expect_diff old_version, new_version, <<-END
+      -Old line
+      +Formatted New line
+      # Comment one
+      # Comment two
+       Formatted Code
+      # Comment three
+    END
 
-    first_line  = lines.first
-    second_line = lines.second
-    third_line  = lines.third
+    first_line, second_line, third_line = diff_lines(old_version, new_version)
 
-    first_line.html.should        eq '-Old line'
     first_line.line_number.should eq ' '
-    first_line.comments.should    be_empty
-    first_line.html_class.should  eq 'removed'
-    first_line.should_not         be_commentable
+    first_line.html_class.should eq 'removed'
+    first_line.should_not be_commentable
 
-    second_line.html.should        eq '+Formatted New line'
     second_line.line_number.should eq 1
-    second_line.comments.should    eq ['Comment one', 'Comment two']
-    second_line.html_class.should  eq 'added'
-    second_line.should             be_commentable
+    second_line.html_class.should eq 'added'
+    second_line.should be_commentable
 
-    third_line.html.should        eq ' Formatted Code'
     third_line.line_number.should eq 2
-    third_line.comments.should    eq ['Comment three']
-    third_line.should             be_commentable
+    third_line.should be_commentable
+  end
+
+  it 'does not interleave sequences of changed lines' do
+    old_version = <<-END
+      Old line 1
+      Old line 2
+      Old line 3
+      Code
+    END
+
+    new_version = <<-END
+      New line 1
+      New line 2
+      New line 3
+      # Comment one
+      Code
+      # Comment two
+    END
+
+    expect_diff old_version, new_version, <<-END
+      -Old line 1
+      -Old line 2
+      -Old line 3
+      +Formatted New line 1
+      +Formatted New line 2
+      +Formatted New line 3
+      # Comment one
+      Formatted Code
+      # Comment two
+    END
+  end
+
+  def diff_lines(old_version, new_version)
+    FormattedCode::Diff.new(
+      code_from_version(old_version),
+      code_from_version(new_version),
+      'ruby',
+      comments_from_version(new_version)
+    ).lines
+  end
+
+  def expect_diff(old_version, new_version, expected_diff)
+    lines    = diff_lines(old_version, new_version)
+    diff     = lines.map(&:html).join("\n")
+    comments = lines.map.with_index { |line, index| [index, line.comments] }.to_h
+
+    actual_diff = code_and_comments_to_version(diff, comments)
+
+    expect(actual_diff).to eq expected_diff.lines.map(&:strip).join("\n")
   end
 end

--- a/spec/lib/formatted_code/diff_spec.rb
+++ b/spec/lib/formatted_code/diff_spec.rb
@@ -5,7 +5,7 @@ describe FormattedCode::Diff do
 
   before do
     FormattedCode::Highlighter.stub :new do |code, language|
-      double lines: code.split("\n").map { |line| "Formatted #{line}" }
+      double lines: code.split("\n").map { |line| "!#{line}" }
     end
   end
 
@@ -25,10 +25,10 @@ describe FormattedCode::Diff do
 
     expect_diff old_version, new_version, <<-END
       -Old line
-      +Formatted New line
+      +!New line
       # Comment one
       # Comment two
-       Formatted Code
+       !Code
       # Comment three
     END
 
@@ -48,31 +48,29 @@ describe FormattedCode::Diff do
 
   it 'does not interleave sequences of changed lines' do
     old_version = <<-END
-      Old line 1
-      Old line 2
-      Old line 3
-      Code
+      puts one
+      puts two
+      puts three
+      puts 42
     END
 
     new_version = <<-END
-      New line 1
-      New line 2
-      New line 3
-      # Comment one
-      Code
-      # Comment two
+      puts first
+      puts second
+      puts third
+      puts 42
+      # This is much better
     END
 
     expect_diff old_version, new_version, <<-END
-      -Old line 1
-      -Old line 2
-      -Old line 3
-      +Formatted New line 1
-      +Formatted New line 2
-      +Formatted New line 3
-      # Comment one
-      Formatted Code
-      # Comment two
+      -puts one
+      -puts two
+      -puts three
+      +!puts first
+      +!puts second
+      +!puts third
+       !puts 42
+       # This is much better
     END
   end
 


### PR DESCRIPTION
Оправих две неща свързани с diff-ването на ревизии и коментарите към тях.

Детайли и примери има в commit съобщенията.

@skanev, може ли да мърджваме ако го ревюират двама от екипа?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/skanev/evans/178)
<!-- Reviewable:end -->
