### PR TITLE
Get tests by test_file_pattern of a Language

### DIFF
--- a/lib/language.rb
+++ b/lib/language.rb
@@ -8,6 +8,7 @@ module Language
            :solution_dump,
            :can_lint?,
            :lint,
+           :test_file,
            to: :current_language
 
   def current_language

--- a/lib/language.rb
+++ b/lib/language.rb
@@ -8,7 +8,7 @@ module Language
            :solution_dump,
            :can_lint?,
            :lint,
-           :test_file,
+           :test_file_pattern,
            to: :current_language
 
   def current_language

--- a/lib/language/clojure.rb
+++ b/lib/language/clojure.rb
@@ -14,7 +14,7 @@ module Language::Clojure
   end
 
   def test_file_pattern
-    'test'
+    'test.clj'
   end
 
   def solution_dump(attributes)

--- a/lib/language/clojure.rb
+++ b/lib/language/clojure.rb
@@ -13,6 +13,10 @@ module Language::Clojure
     false
   end
 
+  def test_file
+    'test'
+  end
+
   def solution_dump(attributes)
     <<-END
 ;;; #{attributes[:name]}

--- a/lib/language/clojure.rb
+++ b/lib/language/clojure.rb
@@ -13,7 +13,7 @@ module Language::Clojure
     false
   end
 
-  def test_file
+  def test_file_pattern
     'test'
   end
 

--- a/lib/language/go.rb
+++ b/lib/language/go.rb
@@ -13,7 +13,7 @@ module Language::Go
     false
   end
 
-  def test_file
+  def test_file_pattern
     '*_test'
   end
 

--- a/lib/language/go.rb
+++ b/lib/language/go.rb
@@ -14,7 +14,7 @@ module Language::Go
   end
 
   def test_file_pattern
-    '*_test'
+    '*_test.go'
   end
 
   def solution_dump(attributes)

--- a/lib/language/go.rb
+++ b/lib/language/go.rb
@@ -13,6 +13,10 @@ module Language::Go
     false
   end
 
+  def test_file
+    '*_test'
+  end
+
   def solution_dump(attributes)
     <<-END
 // #{attributes[:name]}

--- a/lib/language/python.rb
+++ b/lib/language/python.rb
@@ -14,7 +14,7 @@ module Language::Python
   end
 
   def test_file_pattern
-    'test'
+    'test.py'
   end
 
   def solution_dump(attributes)

--- a/lib/language/python.rb
+++ b/lib/language/python.rb
@@ -13,7 +13,7 @@ module Language::Python
     false
   end
 
-  def test_file
+  def test_file_pattern
     'test'
   end
 

--- a/lib/language/python.rb
+++ b/lib/language/python.rb
@@ -13,6 +13,10 @@ module Language::Python
     false
   end
 
+  def test_file
+    'test'
+  end
+
   def solution_dump(attributes)
     <<-END
 # #{attributes[:name]}

--- a/lib/language/ruby.rb
+++ b/lib/language/ruby.rb
@@ -14,7 +14,7 @@ module Language::Ruby
   end
 
   def test_file_pattern
-    'spec'
+    'spec.rb'
   end
 
   def solution_dump(attributes)

--- a/lib/language/ruby.rb
+++ b/lib/language/ruby.rb
@@ -13,6 +13,10 @@ module Language::Ruby
     true
   end
 
+  def test_file
+    'spec'
+  end
+
   def solution_dump(attributes)
     <<-END
 # #{attributes[:name]}

--- a/lib/language/ruby.rb
+++ b/lib/language/ruby.rb
@@ -13,7 +13,7 @@ module Language::Ruby
     true
   end
 
-  def test_file
+  def test_file_pattern
     'spec'
   end
 

--- a/lib/sync/homework.rb
+++ b/lib/sync/homework.rb
@@ -92,7 +92,7 @@ module Sync
     end
 
     def test_file(id)
-      filename = Dir["#{id}/#{Language.test_file_pattern}.#{Language.extension}"].first
+      filename = Dir["#{id}/#{Language.test_file_pattern}"].first
       filename and File.new(filename)
     end
   end

--- a/lib/sync/homework.rb
+++ b/lib/sync/homework.rb
@@ -92,7 +92,7 @@ module Sync
     end
 
     def test_file(id)
-      filename = Dir["#{id}/test*"].first
+      filename = Dir["#{id}/#{Language.test_file}.#{Language.extension}"].first
       filename and File.new(filename)
     end
   end

--- a/lib/sync/homework.rb
+++ b/lib/sync/homework.rb
@@ -92,7 +92,7 @@ module Sync
     end
 
     def test_file(id)
-      filename = Dir["#{id}/#{Language.test_file}.#{Language.extension}"].first
+      filename = Dir["#{id}/#{Language.test_file_pattern}.#{Language.extension}"].first
       filename and File.new(filename)
     end
   end


### PR DESCRIPTION
При изтегляне на задачи от хранилища sync задачата разпознава като тестове само файловете започващи с `test`. Проблемите с този подход:
- Както е описано в #179, в Go за тестове се считат файлове, които завършват на `_test.go`, което води до нуждата в курса по Go тестовете да се именуват `test_test.go`.
- В рамките на курса по Ruby, тези файлове се именуват `spec.rb` и организаторите на курса просто не използват тази функционалност.

Опитвам се да реша този проблем като добавям метод `test_file` в `Language`, връщайки шаблон, по който да се именуват тестови файлове, изключвайки разширението, тъй като то може да бъде взето от метода `extension`. 

Реших да не включвам разширението в `test_file`, за да избегна интерполация на две места (т.е. потребителят на `test_file` се предполага да си вземе разширението). Все още не съм сигурен, че това е добра причина. Освен това, не съм особено възхитен от името `test_file` като цяло. Идеи за по-добро?

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/skanev/evans/181)

<!-- Reviewable:end -->
