### PR TITLE
Hide the tip-of-the-day on mobile

### DIFF
--- a/app/assets/stylesheets/_header.scss
+++ b/app/assets/stylesheets/_header.scss
@@ -32,6 +32,7 @@
     height: 50px;
 
     a.logo { display: none; }
+    .tip-of-the-day { display: none; }
 
     h1 { font-size: 18px; margin-top: 7px; text-align: center; }
 


### PR DESCRIPTION
It breaks the header and is unneeded - there is a link in the menu for
the tips.