### PR TITLE
Run only one test at a time with go runner

### DIFF
--- a/lib/language/go/runner.go
+++ b/lib/language/go/runner.go
@@ -61,7 +61,7 @@ func main() {
 	tests := testNames(os.Args[2])
 
 	for _, test := range tests {
-		cmd := exec.Command("go", "test", "-test.run", test, "-test.timeout", "1s")
+		cmd := exec.Command("go", "test", "-test.run", "^"+test+"(/|$)", "-test.timeout", "1s")
 		out, err := cmd.CombinedOutput()
 
 		if err == nil {


### PR DESCRIPTION
go test's -run  takes a regexp and runs everything that matches it.
'' or '.' or 'Test' all run all tests(All test names must start with
 Test).

This leads to problems when one of the test is called TestSimple and
 another TestSimpler. When the current implementation calls
`go test -run TestSimple` both tests will run.

Additionally go 1.7 introduced subtests (see [1]). If TestSimple had two
subtests named '1' and '2' they can be run by passing TestSimple/1 and
TestSimple/2 to 'go test -run'. Currently we don't need to run subtests
seperately and this will take changes to the code finding out what tests
there are to be ran. Luckily '/' is not a character that can be found in
go's function name, which means that adding '(/|$)' to the end of the
testname we give to '-run' will lead to calling only the test provided
and it's subtests if any.

Example:
Using the above TestSimple and TestSimpler with TestSimple having two
subtests: 'TestSimple(/|$)' will match both the TestSimple
and all of it's subtests and run them as one, but not TestSimpler.

Adding '^' at the begging covers us in case someones names a test
TestTestSimple while having one named TestSimple.

[1] https://blog.golang.org/subtests