### PR TITLE
Better Rust testing

### DIFF
--- a/lib/language/rust.rb
+++ b/lib/language/rust.rb
@@ -64,7 +64,7 @@ module Language::Rust
       results = nil
 
       FileUtils.cd(dir.join('solution')) do
-        results = `cargo test`.strip
+        results = `cargo test 2>&1`.strip
       end
 
       TestResults.new({

--- a/lib/language/rust/syntax_check.rb
+++ b/lib/language/rust/syntax_check.rb
@@ -6,24 +6,33 @@ code = ARGF.read
 
 exit 0 if code.empty?
 
-if code !~ /^\s*fn\s+main\(\s*\)/
-  code += "\nfn main() {\n}\n"
-end
-
 build_result = nil
 
 Dir.mktmpdir do |dir|
   FileUtils.cd(dir) do
-    File.open('code.rs', 'w') do |f|
+    FileUtils.mkdir_p('solution/src')
+
+    File.open('solution/src/lib.rs', 'w') do |f|
       f.write(code)
     end
 
-    build_result = `rustc code.rs 2>&1`
+    File.open('solution/Cargo.toml', 'w') do |f|
+      f.write(<<~EOF)
+        [package]
+        name = "solution"
+        version = "0.1.0"
+        authors = ["Rust Course <fmi@rust-lang.bg>"]
+
+        [dependencies]
+      EOF
+    end
+
+    build_result = `cd solution && cargo build 2>&1`
   end
 end
 
-if build_result.strip.empty?
-  exit 0
-else
+if build_result =~ /error:|warning:/
   exit 1
+else
+  exit 0
 end

--- a/lib/temp_dir.rb
+++ b/lib/temp_dir.rb
@@ -7,6 +7,7 @@ module TempDir
 
       files.each do |name, contents|
         file_path = dir_path.join(name)
+        FileUtils.mkdir_p(file_path.dirname)
         open(file_path, 'w') { |file| file.write contents.encode('utf-8') }
       end
 

--- a/spec/lib/language/parsing_rust_code_spec.rb
+++ b/spec/lib/language/parsing_rust_code_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 describe "Parsing Rust code", rust: true do
   it "returns false for invalid code" do
     Language::Rust.should_not be_parsing <<CODE
-    fn main(
+    fn some_function(
 CODE
   end
 
@@ -16,14 +16,6 @@ CODE
   end
 
   it "returns true for valid code" do
-    Language::Rust.should be_parsing <<CODE
-fn main() {
-
-}
-CODE
-  end
-
-  it "returns true for valid code without a main function" do
     Language::Rust.should be_parsing <<CODE
 pub fn foo() {
 

--- a/spec/lib/language/running_rust_tests_spec.rb
+++ b/spec/lib/language/running_rust_tests_spec.rb
@@ -3,14 +3,16 @@ require 'spec_helper'
 describe "Running Rust tests", rust: true do
   before(:all) do
     @test_case_code = <<END.strip
+extern crate solution;
+
 #[test]
 fn test_code() {
-    assert!(::solution::return_one() == 1i32);
+    assert!(solution::return_one() == 1i32);
 }
 
 #[test]
 fn test_code_2() {
-    assert!(::solution::return_one() != 2i32);
+    assert!(solution::return_one() != 2i32);
 }
 
 #[test]
@@ -36,11 +38,6 @@ END
   def solution
     <<-EOF
       pub fn return_one() -> i32 { 1i32 }
-
-      #[test]
-      fn test_ignored_when_counting_successes() {
-          assert!(return_one() == 1i32);
-      }
     EOF
   end
 
@@ -73,8 +70,6 @@ END
       @results.log.should include("test solution_test::test_expected_failing ... ok")
       @results.log.should include("test solution_test::test_failing ... FAILED")
       @results.log.should include("test solution_test::test_2_failing ... FAILED")
-
-      @results.log.should include("test solution::test_ignored_when_counting_successes ... ok")
     end
   end
 end


### PR DESCRIPTION
Вместо викане на тестове с `rustc`, това ги вика с `cargo test`, което заобикаля някакви малки несъответствия.

Причината изобщо да е PR, е защото променя `TempDir` да създава автоматично директории с `mkdir_p`. Ако по някаква причина това не е ок, мога да го държа в някакъв форк и/или да измисля нещо друго.