### PR TITLE
Fix the Logout link in the menu layout

### DIFF
--- a/app/views/layouts/_menu.html.haml
+++ b/app/views/layouts/_menu.html.haml
@@ -29,4 +29,4 @@
     %li= link_to 'Точки', points_breakdowns_path
 
   - if mobile and user_signed_in?
-    %li= link_to 'Изход', destroy_user_session_path
+    %li= link_to 'Изход', destroy_user_session_path, data: {method: :delete}


### PR DESCRIPTION
В сайта има два бутона за logout. Един горе вдясно в application layout-а (`app/views/layouts/application.html.haml`). И един за мобилни устройства в (`app/views/layouts/_menu.html.haml`). Вторият е счупен.

Този PR го оправя.