### PR TITLE
Add a button for downloading homework solutions

### DIFF
--- a/app/controllers/task_download_controller.rb
+++ b/app/controllers/task_download_controller.rb
@@ -1,0 +1,23 @@
+class TaskDownloadController < ApplicationController
+  include ActionController::Live
+
+  before_action :require_admin
+
+  def create
+    task_id = params[:task_id]
+    task = Task.find task_id
+
+    response.headers['Content-Disposition'] = "attachment; filename=\"homework.tar.gz\""
+
+    TarGzipWriter.wrap(response.stream) do |tar|
+      task.solutions.each do |solution|
+        filename = "#{solution.user.id}-#{solution.user.faculty_number}.#{Language.extension}"
+        code = solution.code
+
+        tar.add_file_simple(filename, 0644, code.bytes.size) { |io| io.write(code) }
+      end
+    end
+  ensure
+    response.stream.close
+  end
+end

--- a/app/services/tar_gzip_writer.rb
+++ b/app/services/tar_gzip_writer.rb
@@ -1,0 +1,11 @@
+require 'rubygems/package'
+
+module TarGzipWriter
+  def self.wrap(io)
+    Zlib::GzipWriter.wrap(io) do |gzip|
+      Gem::Package::TarWriter.new(gzip) do |tar|
+        yield tar
+      end
+    end
+  end
+end

--- a/app/views/solutions/index.html.haml
+++ b/app/views/solutions/index.html.haml
@@ -13,6 +13,7 @@
         за повече информация.
   - else
     = link_to 'Пусни тестовете', task_check_path(@task), method: :create, class: :action
+  = link_to 'Свали като архив', task_download_path(@task), method: :post, class: :action
 
 %p
   %strong= @solutions.count

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@ Trane::Application.routes.draw do
     end
     resource :my_solution, only: %w(show update)
     resource :check, controller: :task_checks, only: :create
+    resource :download, controller: :task_download, only: :create
   end
 
   resources :challenges, except: :destroy do


### PR DESCRIPTION
Искаме да пускаме инструменти разпознаващи плагиатство върху домашните. За целта трябва да свалим всички решения на дадено домашно. Този PR имплементира бутонче, генериращо архив, който съдържа решенията. Бутпонът се намира на страницата със списъка от решения.

Особености:
- архивът е tar.gz; така не се влачат допълнителни dependency-та
- сглобява се on-the-fly; така свалянето е моментално; не се ползва файлова система; не се shell-out-ва